### PR TITLE
source/sinobit/sinobitdisplay.cpp : bit bang, don't hog the SPI hardware

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ micro:bit that's intended to run and support the hardware of the sino:bit.
 
 -   **[Getting Started & Overview](https://learn.adafruit.com/sino-bit-micropython)** - Guide
     on the Adafruit Learning System to help get started using sino:bit MicroPython.  Start here!
--   **[Code Editor]({{ site.url }}{{ site.baseurl }}/editor/editor.html)** - Write sino:bit MicroPython code directly in your
+-   **[Code Editor](https://tdicola.github.io/sinobit-micropython/editor/editor.html)** - Write sino:bit MicroPython code directly in your
     browser and download a firmware to run right on your sino:bit!  This is a
     port of the BBC micro:bit web editor to be compatible with the sino:bit
     MicroPythin firmware in this project.  If you want to program your sino:bit
@@ -80,21 +80,19 @@ _This is currently a brain dump of some ideas, goals, to-dos for this project._
 -   Add support for Chinese text rendering on the matrix.  There is a lot of
     work to investigate here, particularly with text encodings, character sets,
     character representations and rendering.
-    -   Consider using this 12x12 font as a base: https://github.com/SolidZORO/zpix-pixel-font
-    -   Good suggestion to scan source script (like in web editor) and extract
+    -   Consider using [this 12x12 font](https://github.com/SolidZORO/zpix-pixel-font) as a base. 
+    -   [Good suggestion](https://twitter.com/sceptic_int/status/963668006625861635) to scan source script (like in web editor) and extract
         the set of unicode characters in use to inject into the firmware:
-        https://twitter.com/sceptic_int/status/963668006625861635  This
+          This
         could allow a wide range of characters but without dynamic use of them.
     -   Right now have about ~10kb free in firmware (with no loss of modules
         or features yet).  If can get up to ~100kb free could fit ~6k characters.
-    -   Good reference material too: https://r12a.github.io/scripts/chinese/
-        And the GB2312 standard: https://en.wikipedia.org/wiki/GB_2312  Also DB
-        of characters here: http://hanzidb.org/character-list/general-standard
+    -   [Good reference material](https://r12a.github.io/scripts/chinese/) too 
+        And the [GB2312 standard](https://en.wikipedia.org/wiki/GB_2312)  Also [DB of characters](http://hanzidb.org/character-list/general-standard)
     -   Also consider other languages as the zpix font includes Japanese and
-        accented English characters.  There's a Hindi font here too: https://github.com/nishapoyarekar/Sinobit/tree/indic
-    -   Entire unicode font in 16x16 and 8x16 size: http://unifoundry.com/unifont.html
-    -   __Language support is starting to come together!  See a preview here: 
-        https://twitter.com/tdicola/status/965489097769828352__
+        accented English characters.  There's a [Hindi font](https://github.com/nishapoyarekar/Sinobit/tree/indic) here too. 
+    -   [Entire unicode font](http://unifoundry.com/unifont.html) in 16x16 and 8x16 size: 
+    -   __Language support is starting to come together!  See a preview [here](https://twitter.com/tdicola/status/965489097769828352)__
 -   Backwards compatibility with the micro:bit 5x5 LED display.  In theory it's
     possible to upsample drawing commands intended for the micro:bit's 5x5
     display to instead target 2x2 pixel chunks on the 12x12 display (with an

--- a/source/sinobit/sinobitdisplay.cpp
+++ b/source/sinobit/sinobitdisplay.cpp
@@ -1,7 +1,11 @@
-/*
- * The MIT License (MIT)
+/**
  *
- * Copyright (c) 2018 Tony DiCola
+ * @copyright (c) Christoph Maier
+ * @author Christoph Maier.
+ * Licensed under the Apache License 2.0
+ *
+ * based on work by Tony DiCola
+ * under the MIT License (MIT)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -43,202 +47,212 @@ extern "C" {
 // - HT1632C RD/MISO - nRF51 P0.22/41 MISO
 // - HT1632C CS - nRF51 P0.16/22
 //
-// LED matrix is charlieplexed with:
+// LED matrix is multiplexed with:
 // - Rows (common/ground): HTC1632C COM0 to COM11 (12 rows)
 // - Columns (anodes): HTC1632C ROW0 to ROW11 (12 rows)
 //
 // HT1632C needs to be configured with:
 // - N-MOS 24 ROW x 16 COL mode
 
-// HT1632 command and other defines.
-#define HT1632_WRITE         0x2800
-#define HT1632_COMMAND       0x0400
-#define HT1632_SYS_DIS       0x00
-#define HT1632_SYS_EN        0x01
-#define HT1632_LED_OFF       0x02
-#define HT1632_LED_ON        0x03
-#define HT1632_BLINK_OFF     0x08
-#define HT1632_BLINK_ON      0x09
-#define HT1632_RC_MASTER     0x18
-#define HT1632_PWM_CONTROL   0xA0
-#define HT1632_COMMON_16NMOS 0x24
+/******************Instructions**********************/
+#define SYS_DIS 0x00                //Turn off system shock
+#define SYS_EN  0x01                //Turn on  system shock
+#define LED_OFF 0x02                //Turn off LED display
+#define LED_ON  0x03                //Turn on LED display
+#define BLINK_OFF   0x08            //Close blink
+#define BLINK_ON    0x09            //Open blink
+#define SLAVE_MODE  0x10            //Slave mode
+#define RC_MASTER_MODE  0x18        //Use internal clock
+#define COM_OPTION  0x24            //
+#define PWM_CONTROL 0xA0            //PWM Brightness Control
+#define PWM_DUTY    0xAF            //PWM maximum brigntness
+/****************I/O definition**********************/
 
-// Defines to simplify asserting and deasserting the CS line of the display.
-#define ASSERT_HT1632_CS { nrf_gpio_pin_clear(microbit_p16_obj.name); }
-#define DEASSERT_HT1632_CS { nrf_gpio_pin_set(microbit_p16_obj.name); }
+#define HT_CS 16
+#define HT_DATA 21
+#define HT_RD 22
+#define HT_WR 23
 
-// Reference to the HAL SPI bus.
-static spi_t spi;
-// The buffer of pixel data.  Each bit represents a pixel at a row & column
-// and is directly mapped to the HT1632C display memory.  Although only 12x12
-// pixels are used this buffer is padded out to support the full 16x12 pixels
-// of data in the display--this greatly simplfies writing out the data to the
-// display later (the unused columns are ignored and never set).  We get 24
-// bytes because 12 rows * 2 bytes per row (16 pixels).
-uint8_t framebuffer[24] = {0};
+static NRF_GPIO_Type *gpiobase = (NRF_GPIO_Type *)NRF_GPIO_BASE;
+
+static inline void CSon(void) { gpiobase->OUTCLR = 1 << HT_CS; }
+static inline void CSoff(void) { gpiobase->OUTSET = 1 << HT_CS; }
+static inline void RDon(void) { gpiobase->OUTCLR = 1 << HT_RD; }
+static inline void RDoff(void) { gpiobase->OUTSET = 1 << HT_RD; }
+static inline void WRon(void) { gpiobase->OUTCLR = 1 << HT_WR; }
+static inline void WRoff(void) { gpiobase->OUTSET = 1 << HT_WR; }
+static inline void DATA0(void) { gpiobase->OUTCLR = 1 << HT_DATA; }
+static inline void DATA1(void) { gpiobase->OUTSET = 1 << HT_DATA; }
+static inline void RDdata(void) { gpiobase->DIRCLR = 1 << HT_DATA; }
+static inline void WRdata(void) { gpiobase->DIRSET = 1 << HT_DATA; }
+
+static uint8_t com[12] = {
+    0x00, 0x04, 0x08, 0x0C, 0x10, 0x14, 0x18, 0x1C, 0x20, 0x24, 0x28, 0x2C
+};
+
+uint16_t framebuffer[12] = {0};
 
 
-// Send a command to the HT1632 chip.  Specify the 8 bits of the command
-// and it will be sent with the proper header and other state.
-static void ht1632_command(uint8_t command) {
-    // Construct full command as a 16-bit value.  This is actually not correct
-    // because the hardware expects a 12-bit word, but the HAL / hardware
-    // doesn't seem to support _anything_ besides 8-bit words (bytes).  Luckily
-    // it appears the HT1632C ignores trailing bits so we can send a 16-bit
-    // value (two bytes) with the 12-bit command shifted up to the most
-    // significant bits.
-    uint16_t full_command = HT1632_COMMAND | command;
-    full_command <<= 5;  // Shift up so command bits are at top.
-    // Assert CS and send command bytes.
-    ASSERT_HT1632_CS;
-    spi_master_write(&spi, (full_command >> 8) & 0xFF);
-    spi_master_write(&spi, full_command & 0xFF);
-    DEASSERT_HT1632_CS;
+static void HT1632C_Write(uint8_t Data, uint8_t cnt)      //MCU writes the data to ht1632c, and the high position is in front
+{
+    uint8_t i;
+    for (i = 0; i < cnt; i++) {
+        WRon();
+        if (Data & 0x80) {
+            DATA1();
+        } else {
+            DATA0();
+        }
+        Data <<= 1;
+        WRoff();
+    }
 }
 
-// Write 4 bits of display data to the provided 7-bit address.
-static void ht1632_write(uint8_t address, uint8_t data) {
-    // Like with writing a command we have to work with the 8-bit word
-    // constraint of the hardware.  Luckily the HT1632C seems to ignore
-    // trailing bits and we can send the 14 bit display data in a 16 bit word
-    // (two bytes).
-    // First chop off any unused bits from the address and data.
-    address &= 0x7F;  // Address is 7 bits.
-    data &= 0x0F;     // Data is 4 bits.
-    // Construct write command.
-    uint16_t write = HT1632_WRITE | ((uint16_t)address << 4) | data;
-    write <<= 2;  // Shift up so command bits are at top.
-    // Assert CS and send write command bytes.
-    ASSERT_HT1632_CS;
-    spi_master_write(&spi, (write >> 8) & 0xFF);
-    spi_master_write(&spi, write & 0xFF);
-    DEASSERT_HT1632_CS;
+static void HT1632C_Write_CMD(uint8_t cmd) //MCU writes commands to ht1632c
+{
+    WRdata();
+    CSon();
+    HT1632C_Write(0x80, 3);
+    HT1632C_Write(cmd, 9);
+    CSoff();
+}
+
+static void HT1632C_Write_DAT(uint8_t Addr, const uint16_t data[], uint8_t num)
+{
+    WRdata();
+    CSon();
+    HT1632C_Write(0xa0, 3);
+    HT1632C_Write(Addr << 1, 7);
+
+    uint16_t d = data[num];
+    for (uint8_t i = 0; i < 12; i++) {
+        WRon();
+        if (d & 0x8000) {
+            DATA1();
+        } else {
+            DATA0();
+        }
+        d <<= 1;
+        WRoff();
+    }
+    CSoff();
+}
+
+static void HT1632C_clr(void)  //Clear function
+{
+    uint8_t i;
+    WRdata();
+    CSon();
+    HT1632C_Write(0xa0, 3);
+    HT1632C_Write(0x00, 7);
+    for (i = 0; i < 48; i++) {
+        HT1632C_Write(0, 8);
+    }
+    CSoff();
+}
+
+static void HT1632C_Init(void) //HT1632C Init Function
+{
+    gpiobase->OUTSET = 0x00E10000;
+    gpiobase->PIN_CNF[HT_CS] = 0x1;
+    gpiobase->PIN_CNF[HT_RD] = 0x1;
+    gpiobase->PIN_CNF[HT_WR] = 0x1;
+    gpiobase->PIN_CNF[HT_DATA] = 0x1;
+    gpiobase->OUTSET = 0x00E10000;
+    HT1632C_Write_CMD(SYS_DIS);         //Close the HT1632C internal clock
+    HT1632C_Write_CMD(COM_OPTION);      //Select HT1632C work mode
+    HT1632C_Write_CMD(RC_MASTER_MODE);  //Select internal clock
+    HT1632C_Write_CMD(SYS_EN);          //Open the HT1632C internal clock
+    HT1632C_Write_CMD(PWM_DUTY);        //Init the PWM Brightness
+    HT1632C_Write_CMD(BLINK_OFF);       //Close blink
+    HT1632C_Write_CMD(LED_ON);          // Turn on LED display
+}
+
+static uint16_t HT1632C_Read_DATA(uint8_t Addr)
+{
+    WRdata();
+    CSon();
+    HT1632C_Write(0xc0, 3);
+    HT1632C_Write(Addr << 1, 7);
+    RDdata();
+    uint16_t datum = 0;
+    for (uint8_t i = 0; i < 12; i++) {
+        RDon();
+        datum <<= 1;
+        datum |= (gpiobase->IN & (1 << HT_DATA)) >> (HT_DATA-4);
+        RDoff();
+    }
+    CSoff();
+    return datum;
+}
+
+static void HT1632C_Write_Pattern(const uint16_t pattern[])
+{
+    for (int col = 0; col < 12; col++) {
+        HT1632C_Write_DAT(com[col], pattern, col);
+    }
+}
+
+static void HT1632C_Read_Pattern(uint16_t pattern[])
+{
+    for (int col = 0; col < 12; col++) {
+        pattern[col] = HT1632C_Read_DATA(com[col]);
+    }
 }
 
 // Set brightness to a 4-bit value from 0 (low) to 15 (max).
 static void ht1632_brightness(uint8_t brightness) {
     // Clamp brightness value to 0-15.
-    if (brightness > 15) {
-        brightness = 15;
-    }
     // Send brightness command with specified 4 bit value.
-    ht1632_command(HT1632_PWM_CONTROL | (brightness & 0xF));
+    HT1632C_Write_CMD(PWM_CONTROL | (15 > brightness ? brightness : 15));
 }
 
 // Set a pixel at the specified x, y position to the provided value.
 // True turns on a pixel and false turns it off.
 void framebuffer_set(uint8_t x, uint8_t y, bool value) {
     // Ignore values that are out of bounds of the 12x12 portion of display.
-    if ((x > 11) || (y > 11)) {
-      return;
-    }
-    // Calculate bit position of this pixel within framebuffer.
-    uint8_t bit = y*16+x;
-    uint8_t byte_pos = bit / 8;
-    uint8_t byte_offset = bit % 8;
-    // Invert position within each 4 bit nibble to match order of bits for
-    // HT1632 display memory.
-    if (byte_offset < 4) {
-        // 0 1 2 3 -> 3 2 1 0
-        byte_offset = 3 - byte_offset;
-    }
-    else {
-        // 4 5 6 7 -> 7 6 5 4
-        byte_offset = 11 - byte_offset;
-    }
-    // Turn on or off the appropriate bit depending on the value.
-    if (value) {
-        framebuffer[byte_pos] |= (1 << byte_offset);
-    }
-    else {
-        framebuffer[byte_pos] &= ~(1 << byte_offset);
+    if ((x < 12) && (y < 12)) {
+        uint16_t *column = framebuffer+y;
+        uint16_t mask = 0x8000 >> x;
+        if (value)
+            *column |= mask;
+        else
+            *column &= ~mask;
     }
 }
 
 // Get the value of the pixel at the provided x, y position.
 // Returns true if set and false if not set (or an invalid position).
 bool framebuffer_get(uint8_t x, uint8_t y) {
+    bool pixel = 0;
     // Ignore values that are out of bounds of the 12x12 portion of display.
-    if ((x > 11) || (y > 11)) {
-      return false;
+    if ((x < 12) && (y < 12)) {
+        pixel = !(!(framebuffer[y] & (0x8000 >> x)));
     }
-    // Calculate bit position of this pixel within framebuffer.
-    uint8_t bit = y*16+x;
-    uint8_t byte_pos = bit / 8;
-    uint8_t byte_offset = bit % 8;
-    // Invert position within each 4 bit nibble to match order of bits for
-    // HT1632 display memory.
-    if (byte_offset < 4) {
-        // 0 1 2 3 -> 3 2 1 0
-        byte_offset = 3 - byte_offset;
-    }
-    else {
-        // 4 5 6 7 -> 7 6 5 4
-        byte_offset = 11 - byte_offset;
-    }
-    // Check if the bit at the pixel position is set.
-    return (framebuffer[byte_pos] & (1 << byte_offset)) > 0;
+    return pixel;
 }
 
 // Write out the framebuffer data to the display.
 void framebuffer_write() {
-    // Sadly we can't do a single address and success data writes to efficiently
-    // write the framebuffer data in one transaction.  Again the problem is
-    // SPI word size and our limit of using 8-bit words.  The display buffer
-    // data starts with a 14 bit alignment and then 4-bit words.  As a result
-    // we just break down the framebuffer update into individual address writes.
-    uint8_t i = 0;
-    // Write out all 12 rows of the framebuffer.
-    for (int r=0; r<12; r++) {
-        // For each row write out the 4 columns, grabbing the appropriate nibble
-        // of 4-bit data from the framebuffer.
-        uint8_t address = r*4;
-        ht1632_write(address,   framebuffer[i]);
-        ht1632_write(address+1, framebuffer[i] >> 4);
-        i += 1;
-        ht1632_write(address+2, framebuffer[i]);
-        ht1632_write(address+3, framebuffer[i] >> 4);
-        i += 1;
-    }
+    HT1632C_Write_Pattern(framebuffer);
 }
 
 // Set the entire framebuffer with the provided value (true is on, false is off).
 void framebuffer_fill(bool value) {
     // Go through each byte in the buffer and set or unset it appropriately.
-    for (int i=0; i<24; ++i) {
-        if (value) {
-            framebuffer[i] = 0xFF;
-        }
-        else {
-            framebuffer[i] = 0x00;
-        }
+    uint16_t datum = 0;
+    if (value) datum = ~datum;
+    for (int i = 0; i < 12; ++i) {
+        framebuffer[i] = datum;
     }
 }
 
 // Initialize the display hardware.
 void sinobit_display_init() {
-    // Initialize the SPI bus.
-    spi_init(&spi, (PinName)microbit_p15_obj.name,  // MOSI
-                   (PinName)microbit_p14_obj.name,  // MISO
-                   (PinName)microbit_p13_obj.name,  // SCK
-                   NC);                             // CS (CANNOT be set!)
-    spi_format(&spi, 8, 0, 0);     // MUST be 8 bits per word!
-    spi_frequency(&spi, 1000000);  // 1mhz clock
-    // Setup pin 16 CS as output that's high by default.
-    microbit_obj_pin_acquire(&microbit_p16_obj,
-                             microbit_pin_mode_write_digital);
-    nrf_gpio_cfg_output(microbit_p16_obj.name);
-    DEASSERT_HT1632_CS;
-    // Initialize the display.
-    ht1632_command(HT1632_SYS_EN);             // Turn on oscillator
-    ht1632_command(HT1632_LED_ON);             // Turn on LED duty cyle gen
-    ht1632_command(HT1632_BLINK_OFF);          // Turn off blink
-    ht1632_command(HT1632_RC_MASTER);          // RC master mode
-    ht1632_command(HT1632_COMMON_16NMOS);      // 24 x 16 NMOS open drain
-    ht1632_command(HT1632_PWM_CONTROL | 0xF);  // Full PWM duty cycle
+    HT1632C_Init();
     // Clear the screen.
+    HT1632C_clr();
     framebuffer_fill(false);
-    framebuffer_write();
 }
 
 // These are the functions exposed by the module to Python code.  See the
@@ -314,4 +328,4 @@ const mp_obj_module_t sinobitdisplay_module = {
     .globals = (mp_obj_dict_t*)&sinobitdisplay_module_globals,
 };
 
-}
+} // end of extern "C"


### PR DESCRIPTION
sino:bit display driver version that uses GPIO bit banging instead of occupying the SPI hardware block.
With no packet size restriction, the program structure is simpler. 
GPIO registers are accessed directly with no software abstraction layers in between.