### PR TITLE
ports/nrf/boards/sinobit/modules/sinobitdisplay.c : bit bang, don't hog the SPI hardware

### DIFF
--- a/ports/nrf/boards/sinobit/modules/sinobitdisplay.c
+++ b/ports/nrf/boards/sinobit/modules/sinobitdisplay.c
@@ -1,3 +1,12 @@
+/**
+ *
+ * @copyright (c) Christoph Maier
+ * @author Christoph Maier.
+ * based on work by Tony DiCola
+ * Licensed under the Apache License 2.0
+ *
+
+ */
 #include "mphalport.h"
 #include "genhdr/pins.h"
 #include "hal_gpio.h"
@@ -14,204 +23,216 @@
 // - HT1632C RD/MISO - nRF51 P0.22/41 MISO
 // - HT1632C CS - nRF51 P0.16/22
 //
-// LED matrix is charlieplexed with:
+// LED matrix is multiplexed with:
 // - Rows (common/ground): HTC1632C COM0 to COM11 (12 rows)
 // - Columns (anodes): HTC1632C ROW0 to ROW11 (12 rows)
 //
 // HT1632C needs to be configured with:
 // - N-MOS 24 ROW x 16 COL mode
 
-// HT1632 command and other defines.
-#define HT1632_WRITE         0x2800
-#define HT1632_COMMAND       0x0400
-#define HT1632_SYS_DIS       0x00
-#define HT1632_SYS_EN        0x01
-#define HT1632_LED_OFF       0x02
-#define HT1632_LED_ON        0x03
-#define HT1632_BLINK_OFF     0x08
-#define HT1632_BLINK_ON      0x09
-#define HT1632_RC_MASTER     0x18
-#define HT1632_PWM_CONTROL   0xA0
-#define HT1632_COMMON_16NMOS 0x24
+/******************Instructions**********************/
+#define SYS_DIS 0x00                //Turn off system shock
+#define SYS_EN  0x01                //Turn on  system shock
+#define LED_OFF 0x02                //Turn off LED display
+#define LED_ON  0x03                //Turn on LED display
+#define BLINK_OFF   0x08            //Close blink
+#define BLINK_ON    0x09            //Open blink
+#define SLAVE_MODE  0x10            //Slave mode
+#define RC_MASTER_MODE  0x18        //Use internal clock
+#define COM_OPTION  0x24            //
+#define PWM_CONTROL 0xA0            //PWM Brightness Control
+#define PWM_DUTY    0xAF            //PWM maximum brigntness
+/****************I/O definition**********************/
 
-// Defines to simplify asserting and deasserting the CS line of the display.
-#define ASSERT_HT1632_CS { hal_gpio_pin_low(&pin_A16); }
-#define DEASSERT_HT1632_CS { hal_gpio_pin_high(&pin_A16); }
+#define HT_CS 16
+#define HT_DATA 21
+#define HT_RD 22
+#define HT_WR 23
 
-// Define the SPI bus that will be connected to the HT1632.
-#define HTK1632_SPI 1
+static NRF_GPIO_Type *gpiobase = (NRF_GPIO_Type *)NRF_GPIO_BASE;
 
-// The buffer of pixel data.  Each bit represents a pixel at a row & column
-// and is directly mapped to the HT1632C display memory.  Although only 12x12
-// pixels are used this buffer is padded out to support the full 16x12 pixels
-// of data in the display--this greatly simplfies writing out the data to the
-// display later (the unused columns are ignored and never set).  We get 24
-// bytes because 12 rows * 2 bytes per row (16 pixels).
-uint8_t framebuffer[24] = {0};
+static inline void CSon(void) { gpiobase->OUTCLR = 1 << HT_CS; }
+static inline void CSoff(void) { gpiobase->OUTSET = 1 << HT_CS; }
+static inline void RDon(void) { gpiobase->OUTCLR = 1 << HT_RD; }
+static inline void RDoff(void) { gpiobase->OUTSET = 1 << HT_RD; }
+static inline void WRon(void) { gpiobase->OUTCLR = 1 << HT_WR; }
+static inline void WRoff(void) { gpiobase->OUTSET = 1 << HT_WR; }
+static inline void DATA0(void) { gpiobase->OUTCLR = 1 << HT_DATA; }
+static inline void DATA1(void) { gpiobase->OUTSET = 1 << HT_DATA; }
+static inline void RDdata(void) { gpiobase->DIRCLR = 1 << HT_DATA; }
+static inline void WRdata(void) { gpiobase->DIRSET = 1 << HT_DATA; }
+
+static uint8_t com[12] = {
+    0x00, 0x04, 0x08, 0x0C, 0x10, 0x14, 0x18, 0x1C, 0x20, 0x24, 0x28, 0x2C
+};
+
+uint16_t framebuffer[12] = {0};
 
 
-// Send a command to the HT1632 chip.  Specify the 8 bits of the command
-// and it will be sent with the proper header and other state.
-static void ht1632_command(uint8_t command) {
-    // Construct full command as a 16-bit value.  This is actually not correct
-    // because the hardware expects a 12-bit word, but the HAL / hardware
-    // doesn't seem to support _anything_ besides 8-bit words (bytes).  Luckily
-    // it appears the HT1632C ignores trailing bits so we can send a 16-bit
-    // value (two bytes) with the 12-bit command shifted up to the most
-    // significant bits.
-    uint16_t full_command = HT1632_COMMAND | command;
-    full_command <<= 5;  // Shift up so command bits are at top.
-    // Assert CS and send command bytes.
-    uint8_t tx[2] = { (full_command >> 8) & 0xFF,
-                      full_command & 0xFF };
-    ASSERT_HT1632_CS;
-    hal_spi_master_tx_rx(SPI_BASE(HTK1632_SPI), 2, tx, NULL);
-    DEASSERT_HT1632_CS;
+static void HT1632C_Write(uint8_t Data, uint8_t cnt)      //MCU writes the data to ht1632c, and the high position is in front
+{
+    uint8_t i;
+    for (i = 0; i < cnt; i++) {
+        WRon();
+        if (Data & 0x80) {
+            DATA1();
+        } else {
+            DATA0();
+        }
+        Data <<= 1;
+        WRoff();
+    }
 }
 
-// Write 4 bits of display data to the provided 7-bit address.
-static void ht1632_write(uint8_t address, uint8_t data) {
-    // Like with writing a command we have to work with the 8-bit word
-    // constraint of the hardware.  Luckily the HT1632C seems to ignore
-    // trailing bits and we can send the 14 bit display data in a 16 bit word
-    // (two bytes).
-    // First chop off any unused bits from the address and data.
-    address &= 0x7F;  // Address is 7 bits.
-    data &= 0x0F;     // Data is 4 bits.
-    // Construct write command.
-    uint16_t write = HT1632_WRITE | ((uint16_t)address << 4) | data;
-    write <<= 2;  // Shift up so command bits are at top.
-    // Assert CS and send write command bytes.
-    uint8_t tx[2] = { (write >> 8) & 0xFF,
-                      write & 0xFF };
-    ASSERT_HT1632_CS;
-    hal_spi_master_tx_rx(SPI_BASE(HTK1632_SPI), 2, tx, NULL);
-    DEASSERT_HT1632_CS;
+static void HT1632C_Write_CMD(uint8_t cmd) //MCU writes commands to ht1632c
+{
+    WRdata();
+    CSon();
+    HT1632C_Write(0x80, 3);
+    HT1632C_Write(cmd, 9);
+    CSoff();
 }
+
+static void HT1632C_Write_DAT(uint8_t Addr, const uint16_t data[], uint8_t num)
+{
+    WRdata();
+    CSon();
+    HT1632C_Write(0xa0, 3);
+    HT1632C_Write(Addr << 1, 7);
+
+    uint16_t d = data[num];
+    for (uint8_t i = 0; i < 12; i++) {
+        WRon();
+        if (d & 0x8000) {
+            DATA1();
+        } else {
+            DATA0();
+        }
+        d <<= 1;
+        WRoff();
+    }
+    CSoff();
+}
+
+static void HT1632C_clr(void)  //Clear function
+{
+    uint8_t i;
+    WRdata();
+    CSon();
+    HT1632C_Write(0xa0, 3);
+    HT1632C_Write(0x00, 7);
+    for (i = 0; i < 48; i++) {
+        HT1632C_Write(0, 8);
+    }
+    CSoff();
+}
+
+static void HT1632C_Init(void) //HT1632C Init Function
+{
+    gpiobase->OUTSET = 0x00E10000;
+    gpiobase->PIN_CNF[HT_CS] = 0x1;
+    gpiobase->PIN_CNF[HT_RD] = 0x1;
+    gpiobase->PIN_CNF[HT_WR] = 0x1;
+    gpiobase->PIN_CNF[HT_DATA] = 0x1;
+    gpiobase->OUTSET = 0x00E10000;
+    HT1632C_Write_CMD(SYS_DIS);         //Close the HT1632C internal clock
+    HT1632C_Write_CMD(COM_OPTION);      //Select HT1632C work mode
+    HT1632C_Write_CMD(RC_MASTER_MODE);  //Select internal clock
+    HT1632C_Write_CMD(SYS_EN);          //Open the HT1632C internal clock
+    HT1632C_Write_CMD(PWM_DUTY);        //Init the PWM Brightness
+    HT1632C_Write_CMD(BLINK_OFF);       //Close blink
+    HT1632C_Write_CMD(LED_ON);          // Turn on LED display
+}
+
+/*
+static uint16_t HT1632C_Read_DATA(uint8_t Addr)
+{
+    WRdata();
+    CSon();
+    HT1632C_Write(0xc0, 3);
+    HT1632C_Write(Addr << 1, 7);
+    RDdata();
+    uint16_t datum = 0;
+    for (uint8_t i = 0; i < 12; i++) {
+        RDon();
+        datum <<= 1;
+        datum |= (gpiobase->IN & (1 << HT_DATA)) >> (HT_DATA-4);
+        RDoff();
+    }
+    CSoff();
+    return datum;
+}
+*/
+
+static void HT1632C_Write_Pattern(const uint16_t pattern[])
+{
+    for (int col = 0; col < 12; col++) {
+        HT1632C_Write_DAT(com[col], pattern, col);
+    }
+}
+
+/*
+static void HT1632C_Read_Pattern(uint16_t pattern[])
+{
+    for (int col = 0; col < 12; col++) {
+        pattern[col] = HT1632C_Read_DATA(com[col]);
+    }
+}
+*/
 
 // Set brightness to a 4-bit value from 0 (low) to 15 (max).
 static void ht1632_brightness(uint8_t brightness) {
     // Clamp brightness value to 0-15.
-    if (brightness > 15) {
-        brightness = 15;
-    }
     // Send brightness command with specified 4 bit value.
-    ht1632_command(HT1632_PWM_CONTROL | (brightness & 0xF));
+    HT1632C_Write_CMD(PWM_CONTROL | (15 > brightness ? brightness : 15));
 }
 
 // Set a pixel at the specified x, y position to the provided value.
 // True turns on a pixel and false turns it off.
 void framebuffer_set(uint8_t x, uint8_t y, bool value) {
-  // Ignore values that are out of bounds of the 12x12 portion of display.
-  if ((x > 11) || (y > 11)) {
-    return;
-  }
-  // Calculate bit position of this pixel within framebuffer.
-  uint8_t bit = y*16+x;
-  uint8_t byte_pos = bit / 8;
-  uint8_t byte_offset = bit % 8;
-  // Invert position within each 4 bit nibble to match order of bits for
-  // HT1632 display memory.
-  if (byte_offset < 4) {
-    // 0 1 2 3 -> 3 2 1 0
-    byte_offset = 3 - byte_offset;
-  }
-  else {
-    // 4 5 6 7 -> 7 6 5 4
-    byte_offset = 11 - byte_offset;
-  }
-  // Turn on or off the appropriate bit depending on the value.
-  if (value) {
-    framebuffer[byte_pos] |= (1 << byte_offset);
-  }
-  else {
-    framebuffer[byte_pos] &= ~(1 << byte_offset);
-  }
+    // Ignore values that are out of bounds of the 12x12 portion of display.
+    if ((x < 12) && (y < 12)) {
+        uint16_t *column = framebuffer+y;
+        uint16_t mask = 0x8000 >> x;
+        if (value)
+            *column |= mask;
+        else
+            *column &= ~mask;
+    }
 }
 
 // Get the value of the pixel at the provided x, y position.
 // Returns true if set and false if not set (or an invalid position).
 bool framebuffer_get(uint8_t x, uint8_t y) {
-  // Ignore values that are out of bounds of the 12x12 portion of display.
-  if ((x > 11) || (y > 11)) {
-    return false;
-  }
-  // Calculate bit position of this pixel within framebuffer.
-  uint8_t bit = y*16+x;
-  uint8_t byte_pos = bit / 8;
-  uint8_t byte_offset = bit % 8;
-  // Invert position within each 4 bit nibble to match order of bits for
-  // HT1632 display memory.
-  if (byte_offset < 4) {
-    // 0 1 2 3 -> 3 2 1 0
-    byte_offset = 3 - byte_offset;
-  }
-  else {
-    // 4 5 6 7 -> 7 6 5 4
-    byte_offset = 11 - byte_offset;
-  }
-  // Check if the bit at the pixel position is set.
-  return (framebuffer[byte_pos] & (1 << byte_offset)) > 0;
+    bool pixel = 0;
+    // Ignore values that are out of bounds of the 12x12 portion of display.
+    if ((x < 12) && (y < 12)) {
+        pixel = !(!(framebuffer[y] & (0x8000 >> x)));
+    }
+    return pixel;
 }
 
 // Write out the framebuffer data to the display.
 void framebuffer_write() {
-  // Sadly we can't do a single address and success data writes to efficiently
-  // write the framebuffer data in one transaction.  Again the problem is
-  // SPI word size and our limit of using 8-bit words.  The display buffer
-  // data starts with a 14 bit alignment and then 4-bit words.  As a result
-  // we just break down the framebuffer update into individual address writes.
-  uint8_t i = 0;
-  // Write out all 12 rows of the framebuffer.
-  for (int r=0; r<12; r++) {
-    // For each row write out the 4 columns, grabbing the appropriate nibble
-    // of 4-bit data from the framebuffer.
-    uint8_t address = r*4;
-    ht1632_write(address,   framebuffer[i]);
-    ht1632_write(address+1, framebuffer[i] >> 4);
-    i += 1;
-    ht1632_write(address+2, framebuffer[i]);
-    ht1632_write(address+3, framebuffer[i] >> 4);
-    i += 1;
-  }
+    HT1632C_Write_Pattern(framebuffer);
 }
 
 // Set the entire framebuffer with the provided value (true is on, false is off).
 void framebuffer_fill(bool value) {
-  // Go through each byte in the buffer and set or unset it appropriately.
-  for (int i=0; i<24; ++i) {
-    if (value) {
-      framebuffer[i] = 0xFF;
+    // Go through each byte in the buffer and set or unset it appropriately.
+    uint16_t datum = 0;
+    if (value) datum = ~datum;
+    for (int i = 0; i < 12; ++i) {
+        framebuffer[i] = datum;
     }
-    else {
-      framebuffer[i] = 0x00;
-    }
-  }
 }
 
-// Initialization of the sinobit display and HT16K32C hardware.
+// Initialize the display hardware.
 void sinobitdisplay_init0() {
-  // Setup SPI bus 1 as the bus connected to the display driver.
-  // This allows the user to still control the SPI 0 bus for their own needs.
-  hal_spi_init_t spi_init = {
-    .mosi_pin = &pin_A15,
-    .miso_pin = &pin_A14,
-    .clk_pin = &pin_A13,
-    .firstbit = HAL_SPI_MSB_FIRST,
-    .mode = HAL_SPI_MODE_CPOL0_CPHA0,
-    .irq_priority = 3,
-    .freq = HAL_SPI_FREQ_1_Mbps
-  };
-  hal_spi_master_init(SPI_BASE(HTK1632_SPI), &spi_init);
-  // Setup pin 16 CS as output that's high by default.
-  hal_gpio_pin_high(&pin_A16);
-  // Initialize the display.
-  ht1632_command(HT1632_SYS_EN);             // Turn on oscillator
-  ht1632_command(HT1632_LED_ON);             // Turn on LED duty cyle gen
-  ht1632_command(HT1632_BLINK_OFF);          // Turn off blink
-  ht1632_command(HT1632_RC_MASTER);          // RC master mode
-  ht1632_command(HT1632_COMMON_16NMOS);      // 24 x 16 NMOS open drain
-  ht1632_command(HT1632_PWM_CONTROL | 0xF);  // Full PWM duty cycle
+    HT1632C_Init();
+    // Clear the screen.
+    HT1632C_clr();
+    framebuffer_fill(false);
 }
 
 // These are the functions exposed by the module to Python code.  See the


### PR DESCRIPTION
sino:bit display driver version that uses GPIO bit banging instead of occupying the SPI hardware block.
With no packet size restriction, the program structure is simpler.
GPIO registers are accessed directly with no software abstraction layers in between.

As the display in the original branch isn't working, neither is this version.
The equivalent change works in the master branch, though.